### PR TITLE
Fix height of grids in GuideItem

### DIFF
--- a/components/guides/GuideItem.tsx
+++ b/components/guides/GuideItem.tsx
@@ -31,6 +31,7 @@ export const GuideItem: FC<GuideItemProps> = ({
         flexWrap="nowrap"
         spacing={0}
         sx={{
+          height: "100%",
           flexDirection: "row",
           [ps]: { flexDirection: "column" },
           [tl]: { flexDirection: "row" },
@@ -63,7 +64,7 @@ export const GuideItem: FC<GuideItemProps> = ({
           item
           container
           direction="column"
-          sx={{ backgroundColor: lightGrey, mt: 0, p: 4 }}
+          sx={{ height: "100%", backgroundColor: lightGrey, mt: 0, p: 4 }}
         >
           <Grid item>
             <Box


### PR DESCRIPTION
## What?
[UI Fix] Fix height of grids in GuideItem

## Why?
The height of grids inside Link component are undefined which creates inconsistent height and reveals the teal color when hovered. It can be inspected by visiting https://open-archive.org/guides and hovering over the guide items.

Issue - https://imgur.com/51ttNs7

After fix - https://imgur.com/nr2Btny